### PR TITLE
chore: add Hashable as ignored words

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -4,6 +4,7 @@
     "binsize",
     "cpuid",
     "dataframe",
+    "Hashable",
     "lsplit",
     "minc",
     "Passingvalue",


### PR DESCRIPTION
Signed-off-by: hsgwa <19860128+hsgwa@users.noreply.github.com>

"Hashable" is used in CARET_trace.
https://github.com/tier4/CARET_trace/pull/52/files